### PR TITLE
Add support for custom comparator function

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,21 +1,30 @@
+1.1.0 / 2014-09-08
+==================
 
-1.0.0 / 2012-11-07 
+ * Add  constructor param to support custom comparator function
+ * Fix comparation logic to use `opts:comparator`
+ * Add `remotes` option to `component.json`
+ * Merge pull request #3 from repoify/add/repository
+ * add repository field to readme
+ * add .array() and .members() aliases
+
+1.0.0 / 2012-11-07
 ==================
 
   * add .equals(other) support
 
-0.0.4 / 2012-10-17 
+0.0.4 / 2012-10-17
 ==================
 
   * add `Set#each(fn)`
 
-0.0.3 / 2012-09-18 
+0.0.3 / 2012-09-18
 ==================
 
   * add .toJSON()
   * add .isEmpty()
 
-0.0.2 / 2012-09-18 
+0.0.2 / 2012-09-18
 ==================
 
   * rename .empty() to .clear()

--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,32 @@ User.prototype.equals = function(user){
 };
 ```
 
+  Set also supports a custom `comparator` function. This is
+  quite useful when dealing with sets of non-trivial JSON
+  objects that don't have an `.equals(other)`, since adding
+  an `.equals(other)` method is not an option in such a
+  scenario (you'd be overriding `Object`'s prototype).
+
+```js
+var foo = { id: 'foo' };
+var fooish = { id: 'foo' };
+var bar = { id: 'bar' };
+
+var areEqual = function (obj, other) { return obj.id == other.id };
+
+var set = new Set([foo, fooish, bar], {comparator: areEqual});
+
+set.values();
+// => [{ id: 'foo' }, { id: 'bar' }]
+```
+
+Please keep in mind that custom the comparator function, if specified,
+overrides usage of members' `.equals(other)` method.
+
+Bottom line:
+
+`comparator function` > `obj.equals(other)` > `obj == other`
+
 ## API
 
 ### Set()
@@ -45,6 +71,14 @@ User.prototype.equals = function(user){
 ### Set(values)
 
   Create a new `Set` with `values` array. Duplicates will be removed.
+
+### Set(values, opts)
+
+  Create a new `Set` with `values` array and `opts` options. Duplicates will be removed.
+
+  Available options include:
+
+  * `comparator` : *Defaults to* `null`. Defines a custom function to determine equality for set members.
 
 ### Set#add(value)
 
@@ -89,6 +123,6 @@ User.prototype.equals = function(user){
 
   Perform an intersection with `set` and return a new `Set`.
 
-## License 
+## License
 
   MIT

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "set",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "set container",
   "keywords": [
     "set"

--- a/component.json
+++ b/component.json
@@ -2,9 +2,16 @@
   "name": "set",
   "version": "1.0.0",
   "description": "set container",
-  "keywords": ["set"],
-  "scripts": ["index.js"],
+  "keywords": [
+    "set"
+  ],
+  "scripts": [
+    "index.js"
+  ],
   "development": {
     "component/assert": "*"
-  }
+  },
+  "remotes": [
+    "https://raw.githubusercontent.com"
+  ]
 }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function Set(vals, opts) {
 
   // Manage options
   opts = opts || {};
-  this.compare = ('function' == typeof(opts.comparator)) ? opts.comparator : this._defaultComparator;
+  this.areEqual = ('function' == typeof(opts.comparator)) ? opts.comparator : null;
 
   if (vals) {
     for (var i = 0; i < vals.length; ++i) {
@@ -64,8 +64,11 @@ Set.prototype.has = function(val){
 Set.prototype.indexOf = function(val){
   for (var i = 0, len = this.vals.length; i < len; ++i) {
     var obj = this.vals[i];
+
+    // Comparation logic hierarchy
+    if (this.areEqual && this.areEqual(obj, val)) return i;
     if (obj.equals && obj.equals(val)) return i;
-    if (this.compare(obj, val)) return i;
+    if (obj == val) return i;
   }
   return -1;
 };
@@ -192,14 +195,3 @@ Set.prototype.intersect = function(set){
 Set.prototype.isEmpty = function(){
   return 0 == this.vals.length;
 };
-
-/**
- * Default comparator
- *
- * Compares two possible members of the `Set` to determine equality.
- * Should be overriden through `Set` constructor.
- *
- * @return {Boolean}
- * @api private
- */
-var _defaultComparator = function(a, b) { return a == b; };

--- a/index.js
+++ b/index.js
@@ -5,22 +5,29 @@
 
 module.exports = Set;
 
+
 /**
  * Initialize a new `Set` with optional `vals`
  *
- * @param {Array} vals
+ * @param {Array} vals source array
+ * @param {Object} opts options parameter to specify custom `comparator` function
  * @api public
  */
 
-function Set(vals) {
-  if (!(this instanceof Set)) return new Set(vals);
+function Set(vals, opts) {
+  if (!(this instanceof Set)) return new Set(vals, opts);
   this.vals = [];
+
+  // Manage options
+  opts = opts || {};
+  this.compare = ('function' == typeof(opts.comparator)) ? opts.comparator : this._defaultComparator;
+
   if (vals) {
     for (var i = 0; i < vals.length; ++i) {
       this.add(vals[i]);
     }
   }
-}
+};
 
 /**
  * Add `val`.
@@ -58,7 +65,7 @@ Set.prototype.indexOf = function(val){
   for (var i = 0, len = this.vals.length; i < len; ++i) {
     var obj = this.vals[i];
     if (obj.equals && obj.equals(val)) return i;
-    if (obj == val) return i;
+    if (this.compare(obj, val)) return i;
   }
   return -1;
 };
@@ -186,3 +193,13 @@ Set.prototype.isEmpty = function(){
   return 0 == this.vals.length;
 };
 
+/**
+ * Default comparator
+ *
+ * Compares two possible members of the `Set` to determine equality.
+ * Should be overriden through `Set` constructor.
+ *
+ * @return {Boolean}
+ * @api private
+ */
+var _defaultComparator = function(a, b) { return a == b; };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "set-component",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Set container",
   "keywords": [
     "set"
@@ -12,6 +12,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gvilarino/set.git"
+    "url": "https://github.com/component/set.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/component/set.git"
+    "url": "https://github.com/gvilarino/set.git"
   }
 }


### PR DESCRIPTION
This is quite useful when dealing with sets of non-trivial `JSON` objects that don't have an `.equals(other)` (e.g.: an data endpoint response), and adding an `.equals(other)` method is not an option in such a scenario (you'd be overriding `Object`'s prototype).
