### PR TITLE
Add support for custom comparators

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,9 +2,16 @@
   "name": "set",
   "version": "1.0.0",
   "description": "set container",
-  "keywords": ["set"],
-  "scripts": ["index.js"],
+  "keywords": [
+    "set"
+  ],
+  "scripts": [
+    "index.js"
+  ],
   "development": {
     "component/assert": "*"
-  }
+  },
+  "remotes": [
+    "https://raw.githubusercontent.com"
+  ]
 }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function Set(vals, opts) {
 
   // Manage options
   opts = opts || {};
-  this.compare = ('function' == typeof(opts.comparator)) ? opts.comparator : this._defaultComparator;
+  this.areEqual = ('function' == typeof(opts.comparator)) ? opts.comparator : null;
 
   if (vals) {
     for (var i = 0; i < vals.length; ++i) {
@@ -64,8 +64,11 @@ Set.prototype.has = function(val){
 Set.prototype.indexOf = function(val){
   for (var i = 0, len = this.vals.length; i < len; ++i) {
     var obj = this.vals[i];
+
+    // Comparation logic hierarchy
+    if (this.areEqual && this.areEqual(obj, val)) return i;
     if (obj.equals && obj.equals(val)) return i;
-    if (this.compare(obj, val)) return i;
+    if (obj == val) return i;
   }
   return -1;
 };
@@ -192,14 +195,3 @@ Set.prototype.intersect = function(set){
 Set.prototype.isEmpty = function(){
   return 0 == this.vals.length;
 };
-
-/**
- * Default comparator
- *
- * Compares two possible members of the `Set` to determine equality.
- * Should be overriden through `Set` constructor.
- *
- * @return {Boolean}
- * @api private
- */
-var _defaultComparator = function(a, b) { return a == b; };

--- a/index.js
+++ b/index.js
@@ -5,22 +5,29 @@
 
 module.exports = Set;
 
+
 /**
  * Initialize a new `Set` with optional `vals`
  *
- * @param {Array} vals
+ * @param {Array} vals source array
+ * @param {Object} opts options parameter to specify custom `comparator` function
  * @api public
  */
 
-function Set(vals) {
-  if (!(this instanceof Set)) return new Set(vals);
+function Set(vals, opts) {
+  if (!(this instanceof Set)) return new Set(vals, opts);
   this.vals = [];
+
+  // Manage options
+  opts = opts || {};
+  this.compare = ('function' == typeof(opts.comparator)) ? opts.comparator : this._defaultComparator;
+
   if (vals) {
     for (var i = 0; i < vals.length; ++i) {
       this.add(vals[i]);
     }
   }
-}
+};
 
 /**
  * Add `val`.
@@ -58,7 +65,7 @@ Set.prototype.indexOf = function(val){
   for (var i = 0, len = this.vals.length; i < len; ++i) {
     var obj = this.vals[i];
     if (obj.equals && obj.equals(val)) return i;
-    if (obj == val) return i;
+    if (this.compare(obj, val)) return i;
   }
   return -1;
 };
@@ -186,3 +193,13 @@ Set.prototype.isEmpty = function(){
   return 0 == this.vals.length;
 };
 
+/**
+ * Default comparator
+ *
+ * Compares two possible members of the `Set` to determine equality.
+ * Should be overriden through `Set` constructor.
+ *
+ * @return {Boolean}
+ * @api private
+ */
+var _defaultComparator = function(a, b) { return a == b; };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/component/set.git"
+    "url": "https://github.com/gvilarino/set.git"
   }
 }


### PR DESCRIPTION
This is quite useful when dealing with sets of non-trivial `JSON` objects that don't have an `.equals(other)` method or _you don't want to_ give one to them.

For example, a data endpoint response that gives a big collection of `JSON` that are actually instances of `Object`, that you'd like to manage in a `Set` by some criteria, and adding an `.equals(other)` method is not an option in such a scenario because you'd be overriding `Object`'s prototype.
